### PR TITLE
Fixes for DateTime operators and Duration.inWeeks.

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -27,11 +27,11 @@ extension on int {
 extension on DateTime {
   /// Adds this DateTime and Duration and
   /// returns the sum as a new DateTime object.
-  DateTime operator +(Duration duration) => DateTime.add(duration);
+  DateTime operator +(Duration duration) => this.add(duration);
 
   /// Subtracts the Duration from this DateTime
   /// returns the difference as a new DateTime object.
-  DateTime operator -(Duration duration) => DateTime.subtract(duration);
+  DateTime operator -(Duration duration) => this.subtract(duration);
 }
 
 extension on Duration {

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -27,20 +27,16 @@ extension on int {
 extension on DateTime {
   /// Adds this DateTime and Duration and
   /// returns the sum as a new DateTime object.
-  DateTime operator +(Duration duration) {
-    return DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch + duration.inMilliseconds);
-  }
+  DateTime operator +(Duration duration) => DateTime.add(duration);
 
   /// Subtracts the Duration from this DateTime
   /// returns the difference as a new DateTime object.
-  DateTime operator -(Duration duration) {
-    return DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch - duration.inMilliseconds);
-  }
+  DateTime operator -(Duration duration) => DateTime.subtract(duration);
 }
 
 extension on Duration {
   /// Returns the representation in weeks
-  int get inWeeks => (inDays / 4).ceil();
+  int get inWeeks => (inDays / 7).ceil();
 
   /// Adds the Duration to the current DateTime and
   /// returns a DateTime in the future


### PR DESCRIPTION
Current DateTime operator implementation looses microseconds. DateTime has methods provided by native code which will be more optimal for this use-case. Duration.inWeeks incorrect used 4 instead of 7.