### PR TITLE
Add tests to the library

### DIFF
--- a/example/time_example.dart
+++ b/example/time_example.dart
@@ -1,1 +1,22 @@
-void main() {}
+import 'package:time/time.dart';
+
+void main() {
+  // Integer Extensions
+  print(1.weeks);
+  print(7.days);
+  print(22.hours);
+  print(45.minutes);
+  print(30.seconds);
+  print(15.milliseconds);
+  print(10.microseconds);
+  print(5.nanoseconds);
+
+  // DateTime Extensions
+  print(DateTime.now() + 7.days);
+  print(DateTime.now() - 7.days);
+
+  // Duration Extensions
+  print(7.days.inWeeks);
+  print(7.days.later);
+  print(7.days.ago);
+}

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -27,11 +27,11 @@ extension on int {
 extension on DateTime {
   /// Adds this DateTime and Duration and
   /// returns the sum as a new DateTime object.
-  DateTime operator +(Duration duration) => this.add(duration);
+  DateTime operator +(Duration duration) => add(duration);
 
   /// Subtracts the Duration from this DateTime
   /// returns the difference as a new DateTime object.
-  DateTime operator -(Duration duration) => this.subtract(duration);
+  DateTime operator -(Duration duration) => subtract(duration);
 }
 
 extension on Duration {

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,4 +1,4 @@
-extension on int {
+extension IntTimeExtension on int {
   /// Returns a Duration represented in weeks
   Duration get weeks => Duration(days: this * 7);
 
@@ -24,25 +24,21 @@ extension on int {
   Duration get nanoseconds => Duration(microseconds: this ~/ 1000);
 }
 
-extension on DateTime {
-  /// Adds this DateTime and Duration and
-  /// returns the sum as a new DateTime object.
+extension DateTimeTimeExtension on DateTime {
+  /// Adds this DateTime and Duration and returns the sum as a new DateTime object.
   DateTime operator +(Duration duration) => add(duration);
 
-  /// Subtracts the Duration from this DateTime
-  /// returns the difference as a new DateTime object.
+  /// Subtracts the Duration from this DateTime returns the difference as a new DateTime object.
   DateTime operator -(Duration duration) => subtract(duration);
 }
 
-extension on Duration {
+extension DurationTimeExtension on Duration {
   /// Returns the representation in weeks
   int get inWeeks => (inDays / 7).ceil();
 
-  /// Adds the Duration to the current DateTime and
-  /// returns a DateTime in the future
+  /// Adds the Duration to the current DateTime and returns a DateTime in the future
   DateTime get later => DateTime.now() + this;
 
-  /// Subtracts the Duration from the current DateTime and
-  /// returns a DateTime in the past
+  /// Subtracts the Duration from the current DateTime and returns a DateTime in the past
   DateTime get ago => DateTime.now() - this;
 }

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -1,5 +1,76 @@
 import 'package:test/test.dart';
+import 'package:time/time.dart';
 
 void main() {
-  group('A group of tests', () {});
+  group('TimeExtension', () {
+    group('Integers', () {
+      test('can be converted into weeks', () {
+        expect(1.weeks, Duration(days: 7));
+      });
+
+      test('can be converted into days', () {
+        expect(5.days, Duration(days: 5));
+      });
+
+      test('can be converted into hours', () {
+        expect(22.hours, Duration(hours: 22));
+      });
+
+      test('can be converted into minutes', () {
+        expect(45.minutes, Duration(minutes: 45));
+      });
+
+      test('can be converted into seconds', () {
+        expect(30.seconds, Duration(seconds: 30));
+      });
+
+      test('can be converted into milliseconds', () {
+        expect(15.milliseconds, Duration(milliseconds: 15));
+      });
+
+      test('can be converted into microseconds', () {
+        expect(10.microseconds, Duration(microseconds: 10));
+      });
+
+      test('can be converted into nanoseconds', () {
+        expect(5.nanoseconds, Duration(microseconds: 5 ~/ 1000));
+      });
+    });
+
+    group('DateTime', () {
+      test('can subtract Durations', () {
+        expect(
+          DateTime(2019, 1, 1, 0, 0, 30) - 30.seconds,
+          DateTime(2019, 1, 1, 0, 0, 0),
+        );
+      });
+
+      test('can add Durations', () {
+        expect(
+          DateTime(2019, 1, 1, 0, 0, 30) - 30.seconds,
+          DateTime(2019, 1, 1, 0, 0, 0),
+        );
+      });
+    });
+
+    group('Duration', () {
+      test('can be converted to weeks', () {
+        expect(7.days.inWeeks, 1);
+      });
+
+      test('can be converted into a later DateTime', () {
+        expect(7.days.later, _isAbout(DateTime.now() + 7.days));
+      });
+
+      test('can be converted into a previous DateTime', () {
+        expect(7.days.ago, _isAbout(DateTime.now() - 7.days));
+      });
+    });
+  });
 }
+
+// Checks if the two times returned a *just* about equal. Since `later` and
+// `ago` use DateTime.now(), we can't create an expected condition that is
+// exactly equal.
+Matcher _isAbout(DateTime expected) => predicate<DateTime>((dateTime) =>
+    dateTime.millisecondsSinceEpoch - expected.millisecondsSinceEpoch < 1);


### PR DESCRIPTION
This is probably just a bug with the current implementation, but I was not able to write tests against the library until I gave each extension a name.

  - Also adds examples
  - Includes fixes from Simon (slightly corrected)