### PR TITLE
Rename later to fromNow to clarify the origin time

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ final Duration tenMinutes = 10.minutes;
 final DateTime afterTenMinutes = DateTime.now() + 10.minutes;
 final Duration tenMinutesAndSome = 10.minutes + 15.seconds;
 final int tenMinutesInSeconds = 10.minutes.inSeconds;
-final DateTime tenMinutesLater = 10.minutes.later;
+final DateTime tenMinutesFromNow = 10.minutes.fromNow;
 ```
 
 You can perform all basic arithmetic operations on `Duration` as you always have been:
@@ -52,7 +52,7 @@ final int twoMinutesInSeconds = 2.minutes.inSeconds;
 You can also convert `Duration` to `DateTime`, if needed:
 
 ```dart
-final DateTime timeInFuture = 5.minutes.later;
+final DateTime timeInFuture = 5.minutes.fromNow;
 final DateTime timeInPast = 5.minutes.ago;
 ```
 

--- a/example/time_example.dart
+++ b/example/time_example.dart
@@ -17,6 +17,6 @@ void main() {
 
   // Duration Extensions
   print(7.days.inWeeks);
-  print(7.days.later);
+  print(7.days.fromNow);
   print(7.days.ago);
 }

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -37,7 +37,7 @@ extension DurationTimeExtension on Duration {
   int get inWeeks => (inDays / 7).ceil();
 
   /// Adds the Duration to the current DateTime and returns a DateTime in the future
-  DateTime get later => DateTime.now() + this;
+  DateTime get fromNow => DateTime.now() + this;
 
   /// Subtracts the Duration from the current DateTime and returns a DateTime in the past
   DateTime get ago => DateTime.now() - this;

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -58,8 +58,8 @@ void main() {
         expect(7.days.inWeeks, 1);
       });
 
-      test('can be converted into a later DateTime', () {
-        expect(7.days.later, _isAbout(DateTime.now() + 7.days));
+      test('can be converted into a future DateTime', () {
+        expect(7.days.fromNow, _isAbout(DateTime.now() + 7.days));
       });
 
       test('can be converted into a previous DateTime', () {
@@ -69,7 +69,7 @@ void main() {
   });
 }
 
-// Checks if the two times returned a *just* about equal. Since `later` and
+// Checks if the two times returned a *just* about equal. Since `fromNow` and
 // `ago` use DateTime.now(), we can't create an expected condition that is
 // exactly equal.
 Matcher _isAbout(DateTime expected) => predicate<DateTime>((dateTime) =>


### PR DESCRIPTION
Using `.later` doesn't leave clear what the origin time is.
Renamed it to `.fromNow` to clarify that the time is a delta time starting from `DateTime.now()`.

3rd party examples:
**moment.js** uses a [similar nomenclature](https://momentjs.com/docs/#/displaying/fromnow/).
As does [Ruby on Rails](https://www.rubydoc.info/docs/rails/Numeric:from_now).

Fixes #9 