### PR TITLE
Add season extension

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -78,3 +78,49 @@ extension DurationTimeExtension on Duration {
   /// Subtracts the Duration from the current DateTime and returns a DateTime in the past
   DateTime get ago => DateTime.now() - this;
 }
+
+/// Enum representing the seasons
+enum Season {
+  winter,
+  spring,
+  summer,
+  autumn,
+}
+
+extension InverseSeason on Season {
+  Season get inverse => Season.values[(index + 2) % 4];
+}
+
+
+extension SeasonDate on DateTime {
+
+  /// Retrieves the season for the current datetime instance
+  Season get seasonNorth {
+    switch (month) {
+      case 1:
+      case 2:
+        return Season.winter;
+      case 3:
+        return day < 21 ? Season.winter : Season.spring;
+      case 4:
+      case 5:
+        return Season.spring;
+      case 6:
+        return day < 21 ? Season.spring : Season.summer;
+      case 7:
+      case 8:
+        return Season.summer;
+      case 9:
+        return day < 22 ? Season.autumn : Season.summer;
+      case 10:
+      case 11:
+        return Season.autumn;
+      case 12:
+        return day < 22 ? Season.autumn : Season.winter;
+      default:
+        throw ArgumentError('This month doesnt exist #$month.');
+    }
+  }
+
+  Season get seasonSouth => seasonNorth.inverse;
+}

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -142,6 +142,46 @@ void main() {
       });
     });
   });
+  
+  group('Season', () {
+    final year = 1995;
+        group('Inverse',() {
+      test('Season inverse', () {
+        expect(Season.winter.inverse, Season.summer);
+        expect(Season.summer.inverse, Season.winter);
+        expect(Season.autumn.inverse, Season.spring);
+        expect(Season.spring.inverse, Season.autumn);
+      });
+    });
+    group('from datetime', () {
+      test('north', () {
+        expect(DateTime(year, 12, 23).seasonNorth, Season.winter);
+        expect(DateTime(year,3, 20).seasonNorth, Season.winter);
+
+        expect(DateTime(year,3, 21).seasonNorth, Season.spring);
+        expect(DateTime(year,6, 20).seasonNorth, Season.spring);
+
+        expect(DateTime(year,6, 21).seasonNorth, Season.summer);
+        expect(DateTime(year,9, 22).seasonNorth, Season.summer);
+
+        expect(DateTime(year,9, 21).seasonNorth, Season.autumn);
+        expect(DateTime(year,12, 20).seasonNorth, Season.autumn);
+      });
+      test('south', () {
+        expect(DateTime(year, 12, 23).seasonSouth, Season.summer);
+        expect(DateTime(year,3, 20).seasonSouth, Season.summer);
+
+        expect(DateTime(year,3, 21).seasonSouth, Season.autumn);
+        expect(DateTime(year,6, 20).seasonSouth, Season.autumn);
+
+        expect(DateTime(year,6, 21).seasonSouth, Season.winter);
+        expect(DateTime(year,9, 22).seasonSouth, Season.winter);
+
+        expect(DateTime(year,9, 21).seasonSouth, Season.spring);
+        expect(DateTime(year,12, 20).seasonSouth, Season.spring);
+      });
+    });
+  });
 }
 
 // Checks if the two times returned a *just* about equal. Since `fromNow` and


### PR DESCRIPTION
Adds two new getters to DateTime instances.

```dart
DateTime(2001,6, 26).seasonNorth  //  Season.summer
DateTime(2001,6, 26).seasonSouth  // Season.inter
``` 

I couldn't decide if I should create this in a separate package or include this here. So I need your verdict, If you find reasonable adding a season extension to the package, this is ok. If not, just tell me and I publish it separately.