### PR TITLE
Allow the ability to substract a DateTime from another to get the Duration between them

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -36,7 +36,7 @@ extension DateTimeTimeExtension on DateTime {
     } else if (otherTime is DateTime){
       return difference(otherTime)
     } else {
-      throw IllegalArgumentException("${otherTime.toString()} is neither Duration() nor DateTime()");
+      throw ArgumentError.value("${otherTime.toString()} is neither Duration() nor DateTime()");
     }
 
   /// Returns only year, month and day

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -28,8 +28,16 @@ extension DateTimeTimeExtension on DateTime {
   /// Adds this DateTime and Duration and returns the sum as a new DateTime object.
   DateTime operator +(Duration duration) => add(duration);
 
-  /// Subtracts the Duration from this DateTime returns the difference as a new DateTime object.
-  DateTime operator -(Duration duration) => subtract(duration);
+  /// If used with a Duration, it subtracts the Duration from this DateTime returns the difference as a new DateTime object.
+  /// If used with a DateTime it returns the difference between the two DateTime objects as a Duration.
+  DateTime operator -(Comparable otherTime) {
+    if (otherTime is Duration){
+      return subtract(otherTime);
+    } else if (otherTime is DateTime){
+      return difference(otherTime)
+    } else {
+      throw IllegalArgumentException("${otherTime.toString()} is neither Duration() nor DateTime()");
+    }
 
   /// Returns only year, month and day
   DateTime get date => DateTime(year, month, day);

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -79,6 +79,13 @@ void main() {
         );
       });
 
+      test('can subtract DateTime', () {
+        expect(
+          DateTime(2019, 1, 1, 0, 0, 30) - DateTime(2019, 1, 1, 0, 0, 0), 
+          30.seconds);
+      });
+
+
       test('can add Durations', () {
         expect(
           DateTime(2019, 1, 1, 0, 0, 30) - 30.seconds,


### PR DESCRIPTION
Following https://github.com/jogboms/time.dart/issues/27 I added the ability to use the - operation with two DateTime objects.