### PR TITLE
Add isLeapYear, daysInMonth and isAtSameXAs (isAtSameMonth, isAtSameDay, etc.)

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -53,18 +53,9 @@ extension DateTimeTimeExtension on DateTime {
   }
 
   /// Returns true if this year is a leap year.
-  bool get isLeapYear {
-    if (year % 4 == 0) {
-      if (year % 100 == 0) {
-        if (year % 400 == 0) {
-          return true;
-        }
-        return false;
-      }
-      return true;
-    }
-    return false;
-  }
+  bool get isLeapYear =>
+      // Leap years are used since 1582.
+      year >= 1582 && year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
 
   /// Returns the amount of days that are in this month.
   ///

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -67,6 +67,7 @@ extension DateTimeTimeExtension on DateTime {
   }
 
   /// Returns the amount of days that are in this month.
+  ///
   /// Accounts for leap years.
   int get daysInMonth {
     final days = [

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -106,7 +106,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameDayAs(DateTime other) =>
-      isAtSameMonthAs(other) && day == other.day;
+      isAtSameMonthAs(other) && day == other?.day;
 
   /// Returns true if [other] is at the same hour as [this].
   ///
@@ -114,7 +114,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameHourAs(DateTime other) =>
-      isAtSameDayAs(other) && hour == other.hour;
+      isAtSameDayAs(other) && hour == other?.hour;
 
   /// Returns true if [other] is at the same minute as [this].
   ///
@@ -122,7 +122,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameMinuteAs(DateTime other) =>
-      isAtSameHourAs(other) && minute == other.minute;
+      isAtSameHourAs(other) && minute == other?.minute;
 
   /// Returns true if [other] is at the same second as [this].
   ///
@@ -130,7 +130,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameSecondAs(DateTime other) =>
-      isAtSameMinuteAs(other) && second == other.second;
+      isAtSameMinuteAs(other) && second == other?.second;
 
   /// Returns true if [other] is at the same millisecond as [this].
   ///
@@ -139,7 +139,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameMillisecondAs(DateTime other) =>
-      isAtSameSecondAs(other) && millisecond == other.millisecond;
+      isAtSameSecondAs(other) && millisecond == other?.millisecond;
 
   /// Returns true if [other] is at the same microsecond as [this].
   ///

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -93,7 +93,7 @@ extension DateTimeTimeExtension on DateTime {
   /// Does not account for timezones.
   bool isAtSameYearAs(DateTime other) => year == other?.year;
 
-  /// Returns true if [other] is in the same month as [this]/.
+  /// Returns true if [other] is in the same month as [this].
   ///
   /// This means the exact month, including year.
   ///

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -52,6 +52,104 @@ extension DateTimeTimeExtension on DateTime {
     return _calculateDifference(this) == -1;
   }
 
+  /// Returns true if this year is a leap year.
+  bool get isLeapYear {
+    if (year % 4 == 0) {
+      if (year % 100 == 0) {
+        if (year % 400 == 0) {
+          return true;
+        }
+        return false;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /// Returns the amount of days that are in this month.
+  /// Accounts for leap years.
+  int get daysInMonth {
+    final days = [
+      31, // January
+      if (isLeapYear) 29 else 28, // February
+      31, // March
+      30, // April
+      31, // May
+      30, // June
+      31, // July
+      31, // August
+      30, // September
+      31, // October
+      30, // November
+      31, // December
+    ];
+
+    return days[month - 1];
+  }
+
+  /// Returns true if [other] is in the same year as [this].
+  ///
+  /// Does not account for timezones.
+  bool isAtSameYearAs(DateTime other) => year == other?.year;
+
+  /// Returns true if [other] is in the same month as [this]/.
+  ///
+  /// This means the exact month, including year.
+  ///
+  /// Does not account for timezones.
+  bool isAtSameMonthAs(DateTime other) =>
+      isAtSameYearAs(other) && month == other?.month;
+
+  /// Returns true if [other] is on the same day as [this].
+  ///
+  /// This means the exact day, including year and month.
+  ///
+  /// Does not account for timezones.
+  bool isAtSameDayAs(DateTime other) =>
+      isAtSameMonthAs(other) && day == other.day;
+
+  /// Returns true if [other] is at the same hour as [this].
+  ///
+  /// This means the exact hour, including year, month and day.
+  ///
+  /// Does not account for timezones.
+  bool isAtSameHourAs(DateTime other) =>
+      isAtSameDayAs(other) && hour == other.hour;
+
+  /// Returns true if [other] is at the same minute as [this].
+  ///
+  /// This means the exact minute, including year, month, day and hour.
+  ///
+  /// Does not account for timezones.
+  bool isAtSameMinuteAs(DateTime other) =>
+      isAtSameHourAs(other) && minute == other.minute;
+
+  /// Returns true if [other] is at the same second as [this].
+  ///
+  /// This means the exact second, including year, month, day, hour and minute.
+  ///
+  /// Does not account for timezones.
+  bool isAtSameSecondAs(DateTime other) =>
+      isAtSameMinuteAs(other) && second == other.second;
+
+  /// Returns true if [other] is at the same millisecond as [this].
+  ///
+  /// This means the exact millisecond,
+  /// including year, month, day, hour, minute and second.
+  ///
+  /// Does not account for timezones.
+  bool isAtSameMillisecondAs(DateTime other) =>
+      isAtSameSecondAs(other) && millisecond == other.millisecond;
+
+  /// Returns true if [other] is at the same microsecond as [this].
+  ///
+  /// This means the exact microsecond,
+  /// including year, month, day, hour, minute, second and millisecond.
+  ///
+  /// Does not account for timezones.
+  bool isAtSameMicrosecondAs(DateTime other) =>
+      isAtSameMillisecondAs(other) && microsecond == other.microsecond;
+
   static int _calculateDifference(DateTime date) {
     final now = DateTime.now();
     return DateTime(date.year, date.month, date.day).difference(DateTime(now.year, now.month, now.day)).inDays;

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -149,7 +149,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameMicrosecondAs(DateTime other) =>
-      isAtSameMillisecondAs(other) && microsecond == other.microsecond;
+      isAtSameMillisecondAs(other) && microsecond == other?.microsecond;
 
   static int _calculateDifference(DateTime date) {
     final now = DateTime.now();

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -129,6 +129,313 @@ void main() {
         expect(tomorrow.wasYesterday, false);
       });
 
+      test('can handle isLeapYear', () {
+        expect(DateTime(2020, 10, 10).isLeapYear, true);
+        expect(DateTime(2019, 10, 10).isLeapYear, false);
+        expect(DateTime(2100, 01, 01).isLeapYear, false);
+        expect(DateTime(2000, 01, 01).isLeapYear, true);
+      });
+
+      test('can handle daysInMonth', () {
+        // Leap year.
+        expect(DateTime(2020, 01, 01).daysInMonth, 31);
+        expect(DateTime(2020, 02, 01).daysInMonth, 29);
+        expect(DateTime(2020, 03, 01).daysInMonth, 31);
+        expect(DateTime(2020, 04, 01).daysInMonth, 30);
+        expect(DateTime(2020, 05, 01).daysInMonth, 31);
+        expect(DateTime(2020, 06, 01).daysInMonth, 30);
+        expect(DateTime(2020, 07, 01).daysInMonth, 31);
+        expect(DateTime(2020, 08, 01).daysInMonth, 31);
+        expect(DateTime(2020, 09, 01).daysInMonth, 30);
+        expect(DateTime(2020, 10, 01).daysInMonth, 31);
+        expect(DateTime(2020, 11, 01).daysInMonth, 30);
+        expect(DateTime(2020, 12, 01).daysInMonth, 31);
+
+        // Non-leap year.
+        expect(DateTime(2019, 01, 01).daysInMonth, 31);
+        expect(DateTime(2019, 02, 01).daysInMonth, 28);
+        expect(DateTime(2019, 03, 01).daysInMonth, 31);
+        expect(DateTime(2019, 04, 01).daysInMonth, 30);
+        expect(DateTime(2019, 05, 01).daysInMonth, 31);
+        expect(DateTime(2019, 06, 01).daysInMonth, 30);
+        expect(DateTime(2019, 07, 01).daysInMonth, 31);
+        expect(DateTime(2019, 08, 01).daysInMonth, 31);
+        expect(DateTime(2019, 09, 01).daysInMonth, 30);
+        expect(DateTime(2019, 10, 01).daysInMonth, 31);
+        expect(DateTime(2019, 11, 01).daysInMonth, 30);
+        expect(DateTime(2019, 12, 01).daysInMonth, 31);
+      });
+
+      test('can handle isAtSameYearAs', () {
+        expect(
+          DateTime(2020, 10, 10).isAtSameYearAs(DateTime(2020, 09, 12)),
+          true,
+        );
+        expect(
+          DateTime(2019, 10, 10).isAtSameYearAs(DateTime(2020, 10, 10)),
+          false,
+        );
+      });
+
+      test('can handle isAtSameMonthAs', () {
+        expect(
+          DateTime(2020, 10, 18).isAtSameMonthAs(DateTime(2020, 10, 12)),
+          true,
+        );
+        expect(
+          DateTime(2020, 09, 10).isAtSameMonthAs(DateTime(2020, 10, 10)),
+          false,
+        );
+        expect(
+          DateTime(2019, 10, 10).isAtSameMonthAs(DateTime(2020, 10, 10)),
+          false,
+        );
+      });
+
+      test('can handle isAtSameDayAs', () {
+        expect(
+          DateTime(2020, 10, 06, 12).isAtSameDayAs(DateTime(2020, 10, 06, 15)),
+          true,
+        );
+        expect(
+          DateTime(2020, 10, 08, 15).isAtSameDayAs(DateTime(2020, 10, 06, 15)),
+          false,
+        );
+        expect(
+          DateTime(2020, 12, 06, 15).isAtSameDayAs(DateTime(2020, 10, 06, 15)),
+          false,
+        );
+        expect(
+          DateTime(2021, 12, 06, 15).isAtSameDayAs(DateTime(2020, 10, 06, 15)),
+          false,
+        );
+      });
+
+      test('can handle isAtSameHourAs', () {
+        expect(
+          DateTime(2020, 10, 06, 12, 15).isAtSameHourAs(
+            DateTime(2020, 10, 06, 12, 25),
+          ),
+          true,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15).isAtSameHourAs(
+            DateTime(2020, 10, 06, 15, 15),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15).isAtSameHourAs(
+            DateTime(2020, 10, 07, 12, 15),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15).isAtSameHourAs(
+            DateTime(2020, 11, 06, 12, 15),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15).isAtSameHourAs(
+            DateTime(2021, 10, 06, 12, 15),
+          ),
+          false,
+        );
+      });
+
+      test('can handle isAtSameMinuteAs', () {
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30).isAtSameMinuteAs(
+            DateTime(2020, 10, 06, 12, 15, 40),
+          ),
+          true,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30).isAtSameMinuteAs(
+            DateTime(2020, 10, 06, 12, 17, 30),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30).isAtSameMinuteAs(
+            DateTime(2020, 10, 06, 15, 15, 30),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30).isAtSameMinuteAs(
+            DateTime(2020, 10, 09, 12, 15, 30),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30).isAtSameMinuteAs(
+            DateTime(2020, 12, 06, 12, 15, 30),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30).isAtSameMinuteAs(
+            DateTime(2022, 10, 06, 12, 15, 30),
+          ),
+          false,
+        );
+      });
+
+      test('can handle isAtSameSecondAs', () {
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 100).isAtSameSecondAs(
+            DateTime(2020, 10, 06, 12, 15, 30, 150),
+          ),
+          true,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 100).isAtSameSecondAs(
+            DateTime(2020, 10, 06, 12, 15, 45, 100),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 100).isAtSameSecondAs(
+            DateTime(2020, 10, 06, 12, 25, 30, 100),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 100).isAtSameSecondAs(
+            DateTime(2020, 10, 06, 17, 15, 30, 100),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 100).isAtSameSecondAs(
+            DateTime(2020, 10, 02, 12, 15, 30, 100),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 100).isAtSameSecondAs(
+            DateTime(2020, 06, 06, 12, 15, 30, 100),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 100).isAtSameSecondAs(
+            DateTime(2016, 10, 06, 12, 15, 30, 100),
+          ),
+          false,
+        );
+      });
+
+      test('can handle isAtSameMillisecondAs', () {
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMillisecondAs(
+            DateTime(2020, 10, 06, 12, 15, 30, 150, 750),
+          ),
+          true,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMillisecondAs(
+            DateTime(2020, 10, 06, 12, 15, 30, 175, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMillisecondAs(
+            DateTime(2020, 10, 06, 12, 15, 32, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMillisecondAs(
+            DateTime(2020, 10, 06, 12, 18, 30, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMillisecondAs(
+            DateTime(2020, 10, 06, 18, 15, 30, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMillisecondAs(
+            DateTime(2020, 10, 09, 12, 15, 30, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMillisecondAs(
+            DateTime(2020, 04, 06, 12, 15, 30, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMillisecondAs(
+            DateTime(1948, 10, 06, 12, 15, 30, 150, 600),
+          ),
+          false,
+        );
+      });
+
+      test('can handle isAtSameMicrosecondAs', () {
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2020, 10, 06, 12, 15, 30, 150, 600),
+          ),
+          true,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2020, 10, 06, 12, 15, 30, 150, 900),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2020, 10, 06, 12, 15, 30, 160, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2020, 10, 06, 12, 15, 34, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2020, 10, 06, 12, 12, 30, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2020, 10, 06, 07, 15, 30, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2020, 10, 09, 12, 15, 30, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2020, 06, 06, 12, 15, 30, 150, 600),
+          ),
+          false,
+        );
+        expect(
+          DateTime(2020, 10, 06, 12, 15, 30, 150, 600).isAtSameMicrosecondAs(
+            DateTime(2030, 10, 06, 12, 15, 30, 150, 600),
+          ),
+          false,
+        );
+      });
+
       test('can iterate over DateTimes', () {
         final start = DateTime(2019);
         final end = start + 2.days;

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -134,6 +134,8 @@ void main() {
         expect(DateTime(2019, 10, 10).isLeapYear, false);
         expect(DateTime(2100, 01, 01).isLeapYear, false);
         expect(DateTime(2000, 01, 01).isLeapYear, true);
+        expect(DateTime(1000, 01, 01).isLeapYear, false);
+        expect(DateTime(1584, 01, 01).isLeapYear, true);
       });
 
       test('can handle daysInMonth', () {


### PR DESCRIPTION
Hi, I've added some methods/getters that were useful to me:

- `isLeapYear`: Returns whether `this` year is a leap year.
- `daysInMonth`: Returns the amount of days of `this` month. Accounts for leap years.
- `isAtSameXAs(other)`: For example, `isAtSameMonthAs(..)` returns true if the `year` and `month` are the same, even if the `day` or `hour` is different.

`isLeapYear` might also be useful for the age calculation PR (#31).