### PR TITLE
Fix null-safety lints and bumps  #35 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Introduce `isAtSameMinuteAs` extension to `DateTime`
 - Introduce `isAtSameMillisecondAs` extension to `DateTime`
 - Introduce `isAtSameMicrosecondAs` extension to `DateTime`
+- Introduce `isLeapYear` extension to `DateTime`
+- Introduce `daysInMonth` extension to `DateTime`
 
 ```dart
 final DateTime specificDate = DateTime(2021, 01, 01);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.5.0-nullsafety.1
+- Introduce `isAtSameYearAs` extension to `DateTime`
+- Introduce `isAtSameMonthAs` extension to `DateTime`
+- Introduce `isAtSameDayAs` extension to `DateTime`
+- Introduce `isAtSameHourAs` extension to `DateTime`
+- Introduce `isAtSameMinuteAs` extension to `DateTime`
+- Introduce `isAtSameMillisecondAs` extension to `DateTime`
+- Introduce `isAtSameMicrosecondAs` extension to `DateTime`
+
+```dart
+final DateTime specificDate = DateTime(2021, 01, 01);
+final DateTime otherDate = DateTime(2021, 02, 01);
+
+print(specificDate.isAtSameYearAs(otherDate)); // true
+print(specificDate.isAtSameMonthAs(otherDate)); // false
+print(specificDate.isAtSameDayAs(otherDate)); // false
+```
+
 ## 1.5.0-nullsafety.0
 - Migrated to null-safe dart
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ final DateTime end = start + 1.weeks;
 final DateTime tuesday = start.to(end).firstWhere((date) => date.weekday == DateTime.tuesday);
 ```
 
+Granular comparison between `DateTime` fields:
+
+```dart
+final DateTime specificDate = DateTime(2021, 01, 01);
+final DateTime otherDate = DateTime(2021, 02, 01);
+
+print(specificDate.isAtSameYearAs(otherDate)); // true
+print(specificDate.isAtSameMonthAs(otherDate)); // false
+print(specificDate.isAtSameDayAs(otherDate)); // false
+```
+
 You can also delay code execution:
 
 ```dart

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -82,7 +82,7 @@ extension DateTimeTimeExtension on DateTime {
   /// Returns true if [other] is in the same year as [this].
   ///
   /// Does not account for timezones.
-  bool isAtSameYearAs(DateTime other) => year == other?.year;
+  bool isAtSameYearAs(DateTime other) => year == other.year;
 
   /// Returns true if [other] is in the same month as [this].
   ///
@@ -90,7 +90,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameMonthAs(DateTime other) =>
-      isAtSameYearAs(other) && month == other?.month;
+      isAtSameYearAs(other) && month == other.month;
 
   /// Returns true if [other] is on the same day as [this].
   ///
@@ -98,7 +98,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameDayAs(DateTime other) =>
-      isAtSameMonthAs(other) && day == other?.day;
+      isAtSameMonthAs(other) && day == other.day;
 
   /// Returns true if [other] is at the same hour as [this].
   ///
@@ -106,7 +106,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameHourAs(DateTime other) =>
-      isAtSameDayAs(other) && hour == other?.hour;
+      isAtSameDayAs(other) && hour == other.hour;
 
   /// Returns true if [other] is at the same minute as [this].
   ///
@@ -114,7 +114,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameMinuteAs(DateTime other) =>
-      isAtSameHourAs(other) && minute == other?.minute;
+      isAtSameHourAs(other) && minute == other.minute;
 
   /// Returns true if [other] is at the same second as [this].
   ///
@@ -122,7 +122,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameSecondAs(DateTime other) =>
-      isAtSameMinuteAs(other) && second == other?.second;
+      isAtSameMinuteAs(other) && second == other.second;
 
   /// Returns true if [other] is at the same millisecond as [this].
   ///
@@ -131,7 +131,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameMillisecondAs(DateTime other) =>
-      isAtSameSecondAs(other) && millisecond == other?.millisecond;
+      isAtSameSecondAs(other) && millisecond == other.millisecond;
 
   /// Returns true if [other] is at the same microsecond as [this].
   ///
@@ -140,7 +140,7 @@ extension DateTimeTimeExtension on DateTime {
   ///
   /// Does not account for timezones.
   bool isAtSameMicrosecondAs(DateTime other) =>
-      isAtSameMillisecondAs(other) && microsecond == other?.microsecond;
+      isAtSameMillisecondAs(other) && microsecond == other.microsecond;
 
   static int _calculateDifference(DateTime date) {
     final now = DateTime.now();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: time
 description: Type-safe DateTime and Duration calculations, powered by extensions.
-version: 1.5.0-nullsafety.0
+version: 1.5.0-nullsafety.1
 homepage: https://github.com/jogboms/time.dart
 author: Jogboms <jeremiahogbomo@gmail.com>
 


### PR DESCRIPTION
While I was migrating (in my personal project) this package to null-safety, I also needed the additions of #35 - which is not released under `1.4.0` nor `1.5.0-null-safety.0`, so I needed to point to `master` branch of this package.

With this in mind I decided to:

- Add examples in README for `isAtSame` operations;
- Bumped `pubspec.yaml` for a new release;
- Updated the CHANGELOG of this `1.5.0-null-safety.1`, with the additions of #35;
- Removed **linted** errors (in null-safety) about unnecessary `?` null-aware operator in `isAtSame` X extensions.