### PR TITLE
Use clock package to allow for easier testing.

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,3 +1,5 @@
+import 'package:clock/clock.dart';
+
 extension NumTimeExtension<T extends num> on T {
   /// Returns a Duration represented in weeks
   Duration get weeks => days * DurationTimeExtension.daysPerWeek;
@@ -136,7 +138,7 @@ extension DateTimeTimeExtension on DateTime {
   bool isAtSameMicrosecondAs(DateTime other) => isAtSameMillisecondAs(other) && microsecond == other.microsecond;
 
   static int _calculateDifference(DateTime date) {
-    final now = DateTime.now();
+    final now = clock.now();
     return DateTime(date.year, date.month, date.day).difference(DateTime(now.year, now.month, now.day)).inDays;
   }
 
@@ -212,10 +214,10 @@ extension DurationTimeExtension on Duration {
   int get inWeeks => (inDays / daysPerWeek).ceil();
 
   /// Adds the Duration to the current DateTime and returns a DateTime in the future
-  DateTime get fromNow => DateTime.now() + this;
+  DateTime get fromNow => clock.now() + this;
 
   /// Subtracts the Duration from the current DateTime and returns a DateTime in the past
-  DateTime get ago => DateTime.now() - this;
+  DateTime get ago => clock.now() - this;
 
   /// Returns a Future.delayed from this
   Future<void> get delay => Future.delayed(this);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,9 @@ homepage: https://github.com/jogboms/time.dart
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
+dependencies:
+  clock: ^1.1.0
+
 dev_dependencies:
   pedantic: ^1.11.0
   test: ^1.16.5

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -1,7 +1,10 @@
+import 'package:clock/clock.dart';
 import 'package:test/test.dart';
 import 'package:time/time.dart';
 
 void main() {
+  final date = DateTime(2000, 1, 1);
+
   group('TimeExtension', () {
     group('Integers', () {
       test('can be converted into weeks', () {
@@ -103,30 +106,36 @@ void main() {
       });
 
       test('can handle isToday', () {
-        final today = DateTime.now();
-        final yesterday = DateTime.now().subtract(Duration(days: 1));
-        final tomorrow = DateTime.now().add(Duration(days: 1));
-        expect(today.isToday, true);
-        expect(yesterday.isToday, false);
-        expect(tomorrow.isToday, false);
+        final today = date;
+        withClock(Clock.fixed(today), () {
+          final yesterday = today.subtract(Duration(days: 1));
+          final tomorrow = today.add(Duration(days: 1));
+          expect(today.isToday, true);
+          expect(yesterday.isToday, false);
+          expect(tomorrow.isToday, false);
+        });
       });
 
       test('can handle isTomorrow', () {
-        final today = DateTime.now();
-        final yesterday = DateTime.now().subtract(Duration(days: 1));
-        final tomorrow = DateTime.now().add(Duration(days: 1));
-        expect(today.isTomorrow, false);
-        expect(yesterday.isTomorrow, false);
-        expect(tomorrow.isTomorrow, true);
+        final today = date;
+        withClock(Clock.fixed(today), () {
+          final yesterday = today.subtract(Duration(days: 1));
+          final tomorrow = today.add(Duration(days: 1));
+          expect(today.isTomorrow, false);
+          expect(yesterday.isTomorrow, false);
+          expect(tomorrow.isTomorrow, true);
+        });
       });
 
       test('can handle wasYesterday', () {
-        final today = DateTime.now();
-        final yesterday = DateTime.now().subtract(Duration(days: 1));
-        final tomorrow = DateTime.now().add(Duration(days: 1));
-        expect(today.wasYesterday, false);
-        expect(yesterday.wasYesterday, true);
-        expect(tomorrow.wasYesterday, false);
+        final today = date;
+        withClock(Clock.fixed(today), () {
+          final yesterday = today.subtract(Duration(days: 1));
+          final tomorrow = today.add(Duration(days: 1));
+          expect(today.wasYesterday, false);
+          expect(yesterday.wasYesterday, true);
+          expect(tomorrow.wasYesterday, false);
+        });
       });
 
       test('can handle isLeapYear', () {
@@ -535,11 +544,15 @@ void main() {
     });
 
     test('can be converted into a future DateTime', () {
-      expect(7.days.fromNow, _isAbout(DateTime.now() + 7.days));
+      withClock(Clock.fixed(date), () {
+        expect(7.days.fromNow, date + 7.days);
+      });
     });
 
     test('can be converted into a previous DateTime', () {
-      expect(7.days.ago, _isAbout(DateTime.now() - 7.days));
+      withClock(Clock.fixed(date), () {
+        expect(7.days.ago, date - 7.days);
+      });
     });
 
     test('Can be used to pause the program flow', () async {
@@ -552,9 +565,3 @@ void main() {
     });
   });
 }
-
-// Checks if the two times returned a *just* about equal. Since `fromNow` and
-// `ago` use DateTime.now(), we can't create an expected condition that is
-// exactly equal.
-Matcher _isAbout(DateTime expected) =>
-    predicate<DateTime>((dateTime) => dateTime.millisecondsSinceEpoch - expected.millisecondsSinceEpoch < 1);


### PR DESCRIPTION
This PR allows the Time package to use the official [clock](https://pub.dev/packages/clock) package published by the Dart tools team. By using `clock.now()` instead of `DateTime.now()`, code which is time-dependent can be easily tested using the clock package's `withClock` test utility function.

Here's [a lovely article](https://iiro.dev/controlling-time-with-package-clock/) about using the clock package to test time-dependent code.

This also makes the unit tests here a little bit cleaner. If you have any feedback, let me know! Thank you for making this package.