### PR TITLE
Added config files for project line length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ build/
 doc/api/
 
 # JetBrains IDEs
-.idea/
+.idea/*
 *.iml
 *.ipr
 *.iws

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="Dart">
+      <option name="RIGHT_MARGIN" value="120" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "dart.lineLength": 120,
+  "[dart]": {
+      "editor.tabSize": 2,
+      "editor.rulers": [
+          120
+      ],
+  },
+}


### PR DESCRIPTION
Since my last contribution, I figured I could suggest these files so that people using VSCode or Android Studio/IntelliJ that work on this project will always get the right line length for dart formatting.