### PR TITLE
Fix wrong assertion when equal

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -249,8 +249,8 @@ extension DateTimeTimeExtension on DateTime {
   /// ```
   DateTime clamp({DateTime? min, DateTime? max}) {
     assert(
-      ((min != null) && (max != null)) ? min.compareTo(max).isNegative : true,
-      'DateTime min has to be before max\n(min: $min - max: $max)',
+      ((min != null) && (max != null)) ? (min.isBefore(max) || (min == max)) : true,
+      'DateTime min has to be before or equal to max\n(min: $min - max: $max)',
     );
     if ((min != null) && compareTo(min).isNegative) {
       return min;

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -640,6 +640,13 @@ void main() {
           throwsA(isA<AssertionError>()),
         );
       });
+
+      test('returns min/max if are equal', () {
+        final it = DateTime(2022, DateTime.september, 1);
+        final min = DateTime(2022, DateTime.september, 30);
+        final max = min;
+        expect(it.clamp(min: min, max: max), min);
+      });
     });
   });
 


### PR DESCRIPTION
Found a bug. When both `min` and `max` were equal, the assertion was throwing. Added a test to maintain that as well. The documentation above was correct, must have missed it when publishing the first time.