### PR TITLE
Fix `Duration.clamp` min=max bug

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -301,7 +301,7 @@ extension DurationTimeExtension on Duration {
   /// ```
   Duration clamp({Duration? min, Duration? max}) {
     assert(
-      ((min != null) && (max != null)) ? min.compareTo(max).isNegative : true,
+      ((min != null) && (max != null)) ? min.compareTo(max) <= 0 : true,
       'Duration min has to be shorter than max\n(min: $min - max: $max)',
     );
     if ((min != null) && compareTo(min).isNegative) {

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -744,6 +744,13 @@ void main() {
           throwsA(isA<AssertionError>()),
         );
       });
+
+      test('returns min/max if are equal', () {
+        final it = Duration(days: -0);
+        final min = Duration(days: 5);
+        final max = min;
+        expect(it.clamp(min: min, max: max), min);
+      });
     });
   });
 }


### PR DESCRIPTION
Missed in #61 