### PR TITLE
Adding endOfDay getter

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -296,6 +296,19 @@ extension DateTimeTimeExtension on DateTime {
   bool get isWeekend => (weekday == DateTime.saturday) || (weekday == DateTime.sunday);
 
   bool get isWorkday => !isWeekend;
+
+  /// Returns the last microsecond of the day (23:59:59.999999)
+  /// ```dart
+  /// final date = DateTime(2020, 1, 1);
+  /// date.endOfDay; // 2020-01-01 23:59:59.999999
+  /// final date = DateTime(2020, 1, 1, 12, 30, 15, 123, 456);
+  /// date.endOfDay; // 2020-01-01 23:59:59.999999
+  /// ```
+  DateTime get endOfDay {
+    const microsecond = Duration(microseconds: 1);
+    if (isUtc) return DateTime.utc(year, month, day + 1) - microsecond;
+    return DateTime(year, month, day + 1) - microsecond;
+  }
 }
 
 extension DurationTimeExtension on Duration {

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -716,7 +716,18 @@ void main() {
         expect(it.isWorkday, isFalse);
       });
     });
-
+    group('EndOfDay', () {
+      test('returns the last microsecond of the day', () {
+        final it = DateTime(2022, DateTime.august, 1, 12, 30, 15, 10, 5);
+        final expected = DateTime(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        expect(it.endOfDay, expected);
+      });
+      test('returns the last microsecond of the day for utc', () {
+        final it = DateTime.utc(2022, DateTime.august, 1, 12, 30, 15, 10, 5);
+        final expected = DateTime.utc(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        expect(it.endOfDay, expected);
+      });
+    });
     group('Shift', () {
       group('empty parameters', () {
         test('local', () {


### PR DESCRIPTION
Here is the new end of day getter to work with the `date` getter.

More context at https://github.com/jogboms/time.dart/discussions/69