### PR TITLE
fea: add isInRange extension

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -309,6 +309,31 @@ extension DateTimeTimeExtension on DateTime {
     if (isUtc) return DateTime.utc(year, month, day + 1) - microsecond;
     return DateTime(year, month, day + 1) - microsecond;
   }
+
+  /// Returns true if this DateTime is in the range [start]-[end].
+  ///
+  /// [startInclusive] and [endInclusive] control the range boundaries:
+  /// - Left-open right-open (false, false): (start, end)
+  /// - Left-open right-closed (false, true): (start, end]
+  /// - Left-closed right-open (true, false): [start, end)
+  /// - Left-closed right-closed (true, true): [start, end]
+  bool isInRange(
+    DateTime start,
+    DateTime end, {
+    bool startInclusive = false,
+    bool endInclusive = false,
+  }) {
+    final left = compareTo(start);
+    final right = compareTo(end);
+    if (startInclusive && endInclusive) {
+      return left >= 0 && right <= 0;
+    } else if (startInclusive) {
+      return left >= 0 && right < 0;
+    } else if (endInclusive) {
+      return left > 0 && right <= 0;
+    }
+    return left > 0 && right < 0;
+  }
 }
 
 extension DurationTimeExtension on Duration {

--- a/test/time_test.dart
+++ b/test/time_test.dart
@@ -728,6 +728,40 @@ void main() {
         expect(it.endOfDay, expected);
       });
     });
+    group('IsInRange', () {
+      test('returns true if the date is in the range', () {
+        final it = DateTime(2022, DateTime.august, 1, 1, 0, 0, 0, 0);
+        final start = DateTime(2022, DateTime.august, 1, 0, 0, 0, 0, 0);
+        final end = DateTime(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        expect(it.isInRange(start, end), isTrue);
+      });
+      test('returns false if the date is not in the range', () {
+        final it = DateTime(2022, DateTime.august, 0, 0, 0, 0, 0, 0);
+        final start = DateTime(2022, DateTime.august, 1, 0, 0, 0, 0, 0);
+        final end = DateTime(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        expect(it.isInRange(start, end), isFalse);
+      });
+      test('returns true if the date is in the range with startInclusive true', () {
+        final it = DateTime(2022, DateTime.august, 1, 0, 0, 0, 0, 0);
+        final start = DateTime(2022, DateTime.august, 1, 0, 0, 0, 0, 0);
+        final end = DateTime(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        expect(it.isInRange(start, end, startInclusive: true), isTrue);
+      });
+      test('returns true if the date is in the range with endInclusive true', () {
+        final it = DateTime(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        final start = DateTime(2022, DateTime.august, 1, 0, 0, 0, 0, 0);
+        final end = DateTime(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        expect(it.isInRange(start, end, endInclusive: true), isTrue);
+      });
+      test('returns true if the date is in the range with both startInclusive and endInclusive true', () {
+        final it1 = DateTime(2022, DateTime.august, 1, 0, 0, 0, 0, 0);
+        final it2 = DateTime(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        final start = DateTime(2022, DateTime.august, 1, 0, 0, 0, 0, 0);
+        final end = DateTime(2022, DateTime.august, 1, 23, 59, 59, 999, 999);
+        expect(it1.isInRange(start, end, startInclusive: true, endInclusive: true), isTrue);
+        expect(it2.isInRange(start, end, startInclusive: true, endInclusive: true), isTrue);
+      });
+    });
     group('Shift', () {
       group('empty parameters', () {
         test('local', () {


### PR DESCRIPTION

```dart
 Returns true if this DateTime is in the range [start]-[end].
  [startInclusive] and [endInclusive] control the range boundaries:
- Left-open right-open (false, false): (start, end)
- Left-open right-closed (false, true): (start, end]
- Left-closed right-open (true, false): [start, end)
- Left-closed right-closed (true, true): [start, end]
```